### PR TITLE
went from default cost (12) to 4 for performance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,11 +19,11 @@
 	"settings": {},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"matklad.rust-analyzer",
 		"vadimcn.vscode-lldb",
-		"be5invis.toml",
 		"ms-azuretools.vscode-docker",
-		"serayuzgur.crates"
+		"bungcip.better-toml",
+		"serayuzgur.crates",
+		"rust-lang.rust-analyzer"
 	]
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/src/utils/encryption.rs
+++ b/src/utils/encryption.rs
@@ -1,8 +1,8 @@
 extern crate bcrypt;
-use bcrypt::{DEFAULT_COST, hash, verify};
+use bcrypt::{hash, verify};
 /// Hashes a string value, used for encrypted passwords.
 pub fn encrypt(s: &String) -> String {
-    hash(&s, DEFAULT_COST).unwrap()
+    hash(&s, 4).unwrap()
 }
 /// Checks if a normal string and a hashed string are the same.
 /// This is used to check if a user filled in the correct password.


### PR DESCRIPTION
I've changed DEFAULT_COST (which is 12) in `utils/encrypt.rs` to 4 which is the bare minimum. The cost you can use on the bcrypt hash function has to be between 4 and 31 included.
Using the cost 4 gives me almost instant results running on my local machine.
On the repo of this used crate they showed the following benchmarks:
```
Benchmarks

Speed depends on the cost used: the highest the slowest. Here are some benchmarks on a 2019 Macbook Pro to give you some ideas on the cost/speed ratio. Note that I don't go above 14 as it takes too long.

test bench_cost_10      ... bench:  51,474,665 ns/iter (+/- 16,006,581)
test bench_cost_14      ... bench: 839,109,086 ns/iter (+/- 274,507,463)
test bench_cost_4       ... bench:     795,814 ns/iter (+/- 42,838)
test bench_cost_default ... bench: 195,344,338 ns/iter (+/- 8,329,675)

```
Link to the crate: https://crates.io/crates/bcrypt
closes #4 